### PR TITLE
SC-40608: Identify more accurately if alembic.ddl is present within application.

### DIFF
--- a/sqlalchemy_databricks/_dialect.py
+++ b/sqlalchemy_databricks/_dialect.py
@@ -11,7 +11,9 @@ from sqlalchemy.sql import compiler
 
 try:
     import alembic
+    import alembic.ddl
 except ImportError:
+    # No alembic library is acceptable
     pass
 else:
     from alembic.ddl import DefaultImpl


### PR DESCRIPTION
To have dumbledore use this library, it requires alembic.ddl, presumably because it has alembic folder.
This more accurate check should eliminate the need to depend on alembic library in dumbledore.